### PR TITLE
Filebeat data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     build: filebeat/.
     volumes:
       - ./filebeat/input_files:/usr/share/filebeat/input_files
+      - ./filebeat/filebeat_data:/usr/share/filebeat/data
     depends_on:
       - "logstash"
     restart: always

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -3,3 +3,4 @@ FROM docker.elastic.co/beats/filebeat:7.2.0
 ADD ./filebeat.yml /usr/share/filebeat/filebeat.yml
 USER root
 RUN chmod go-w /usr/share/filebeat/filebeat.yml
+USER filebeat

--- a/filebeat/filebeat_data/README.md
+++ b/filebeat/filebeat_data/README.md
@@ -1,3 +1,3 @@
 # filebeat_data
 
-This folder will store the metadata and registry file that Filebeat uses to track where it was last reading. Mounting this local drive to the Docker container will allow Filebeat to restart without losing it's reading position.
+This folder will store the metadata and registry file that Filebeat uses to track where it was last reading. Mounting this local directory to the Docker container will allow Filebeat to restart without losing it's reading position.

--- a/filebeat/filebeat_data/README.md
+++ b/filebeat/filebeat_data/README.md
@@ -1,0 +1,3 @@
+# filebeat_data
+
+This folder will store the metadata and registry file that Filebeat uses to track where it was last reading. Mounting this local drive to the Docker container will allow Filebeat to restart without losing it's reading position.


### PR DESCRIPTION
Mounts the filebeat metadata and registry file to a local directory so that filebeat will not reread data in the scenario the container restarts. 